### PR TITLE
feat: improve responsive layout

### DIFF
--- a/src/app/highscores/page.tsx
+++ b/src/app/highscores/page.tsx
@@ -55,30 +55,30 @@ export default function HighScoresPage() {
     current && scores.findIndex((s) => s.name === current.name) === -1;
 
   return (
-    <main className="min-h-screen p-6 flex flex-col items-center gap-6">
+    <main className="min-h-screen p-4 sm:p-6 flex flex-col items-center gap-6">
       <h1 className="text-3xl font-bold">High Scores</h1>
       <ol className="w-full max-w-md space-y-2">
         {scores.map((item, idx) => (
           <li
             key={idx}
-            className={`flex items-center justify-between text-sm ${
+            className={`grid grid-cols-[auto_1fr_auto] sm:grid-cols-[auto_1fr_auto_auto] items-center gap-2 text-sm ${
               current?.name === item.name ? "text-emerald-400" : ""
             }`}
           >
-            <span className="w-6 text-left">{idx + 1}</span>
-            <span className="flex-1 font-medium">{item.name}</span>
-            <span className="w-10 text-right">{item.score}</span>
-            <span className="w-24 text-right text-gray-400">
+            <span>{idx + 1}</span>
+            <span className="font-medium truncate">{item.name}</span>
+            <span className="text-right">{item.score}</span>
+            <span className="text-right text-gray-400 hidden sm:block">
               {new Date(item.created_at).toLocaleDateString()}
             </span>
           </li>
         ))}
         {showExtraRow && current && (
-          <li className="flex items-center justify-between text-sm border-t border-gray-700 pt-2 mt-2">
-            <span className="w-6 text-left">{current.rank}</span>
-            <span className="flex-1 font-medium">{current.name}</span>
-            <span className="w-10 text-right">{current.score}</span>
-            <span className="w-24 text-right text-gray-400">
+          <li className="grid grid-cols-[auto_1fr_auto] sm:grid-cols-[auto_1fr_auto_auto] items-center gap-2 text-sm border-t border-gray-700 pt-2 mt-2">
+            <span>{current.rank}</span>
+            <span className="font-medium truncate">{current.name}</span>
+            <span className="text-right">{current.score}</span>
+            <span className="text-right text-gray-400 hidden sm:block">
               {new Date(current.created_at).toLocaleDateString()}
             </span>
           </li>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 
 export default function Page() {
   return (
-    <main className="min-h-screen flex flex-col items-center justify-center p-6 gap-6">
+    <main className="min-h-screen flex flex-col items-center justify-center p-4 sm:p-6 gap-6">
       <div className="text-center space-y-2">
         <h1 className="text-4xl md:text-5xl font-extrabold tracking-tight">🎬 What The Film</h1>
         <p className="text-gray-300">Can you guess the movie from a single backdrop?</p>

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -205,7 +205,7 @@ export default function Game() {
 
   return (
     <div className="w-full max-w-4xl">
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between mb-4">
         <div className="flex items-center gap-4">
           <div className="text-lg font-semibold">
             Score: <span className="text-emerald-400">{score}</span>
@@ -218,9 +218,9 @@ export default function Game() {
             ))}
           </div>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 w-full sm:w-auto">
           <div className="text-lg font-semibold">Time:</div>
-          <div className="w-48 h-3 rounded-full bg-gray-800 overflow-hidden">
+          <div className="flex-1 sm:w-48 h-3 rounded-full bg-gray-800 overflow-hidden">
             <motion.div
               key={question}
               className="h-full bg-rose-500"
@@ -261,7 +261,7 @@ export default function Game() {
         </div>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         {options.map((opt) => (
           <button
             key={opt}


### PR DESCRIPTION
## Summary
- make game header and options responsive for small screens
- adapt main page and high scores layout for mobile/desktop

## Testing
- `pnpm lint` *(fails: Command "lint" not found)*
- `pnpm build`
- `pnpm run test` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_6899eeed5a74832283ad566678851dfd