### PR TITLE
Show missed movies with IMDb links on game over screen

### DIFF
--- a/src/app/api/tmdb/movie/[id]/route.ts
+++ b/src/app/api/tmdb/movie/[id]/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+  const apiKey = process.env.TMDB_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json({ error: "TMDB_API_KEY is missing" }, { status: 500 });
+  }
+
+  const { id } = params;
+  const url = new URL(`https://api.themoviedb.org/3/movie/${id}`);
+  url.searchParams.set("api_key", apiKey);
+  url.searchParams.set("language", "en-US");
+
+  const resp = await fetch(url.toString(), { cache: "no-store" });
+  const data = await resp.json();
+
+  return NextResponse.json({
+    id: data.id,
+    title: data.title,
+    rating: data.vote_average,
+    imdb_id: data.imdb_id,
+  });
+}

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -17,6 +17,7 @@ export default function Game() {
   const [imgUrl, setImgUrl] = useState<string>("");
   const [options, setOptions] = useState<string[]>([]);
   const [correct, setCorrect] = useState<string>("");
+  const [currentMovie, setCurrentMovie] = useState<Movie | null>(null);
   const [loading, setLoading] = useState(false);
   const [selected, setSelected] = useState<string>("");
   const [showAnswer, setShowAnswer] = useState(false);
@@ -27,6 +28,9 @@ export default function Game() {
     { name: string; score: number; created_at: string }[]
   >([]);
   const [lives, setLives] = useState(3);
+  const [missed, setMissed] = useState<
+    { id: number; title: string; rating: number; imdb_id: string | null }[]
+  >([]);
   const timerRef = useRef<NodeJS.Timeout | null>(null);
 
   async function loadBatch() {
@@ -92,6 +96,7 @@ export default function Game() {
     rem = rem.filter((m) => !others.includes(m));
     setRemaining(rem);
     setCorrect(pick.title);
+    setCurrentMovie(pick);
     setOptions(shuffle([pick.title, ...others.map((m) => m.title)]));
     const path = encodeURIComponent(pick.backdrop_path || "");
     const url = `/api/img?path=${path}&w=1280`;
@@ -100,7 +105,17 @@ export default function Game() {
     setTimeout(() => setLoading(false), 150);
   }
 
-  function handleMistake() {
+  async function handleMistake() {
+    if (currentMovie) {
+      try {
+        const details = await fetch(
+          `/api/tmdb/movie/${currentMovie.id}`
+        ).then((r) => r.json());
+        setMissed((prev) => [...prev, details]);
+      } catch {
+        // ignore
+      }
+    }
     const nextLives = lives - 1;
     setLives(nextLives);
     if (nextLives <= 0) {
@@ -158,6 +173,8 @@ export default function Game() {
     setGameOver(false);
     setLives(3);
     setRemaining([]);
+    setMissed([]);
+    setCurrentMovie(null);
     await loadBatch();
     startRound();
   }
@@ -196,6 +213,29 @@ export default function Game() {
             </li>
           ))}
         </ol>
+        {missed.length > 0 && (
+          <div className="mt-4">
+            <h3 className="font-semibold">Missed Movies</h3>
+            <ul className="space-y-1 text-sm">
+              {missed.map((m) => (
+                <li key={m.id}>
+                  {m.imdb_id ? (
+                    <a
+                      href={`https://www.imdb.com/title/${m.imdb_id}/`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline"
+                    >
+                      {m.title}
+                    </a>
+                  ) : (
+                    <span>{m.title}</span>
+                  )}{" "}- ⭐ {m.rating ? m.rating.toFixed(1) : "N/A"}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
         <button className="btn" onClick={restart}>
           Play Again
         </button>


### PR DESCRIPTION
## Summary
- track missed movies during gameplay and fetch TMDB details
- display missed movies with rating and IMDb link on the game over screen
- expose `/api/tmdb/movie/[id]` endpoint to provide movie details

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Missing script "lint")
- `npm run typecheck` (fails: Missing script "typecheck")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a0a841c4883229ef82623c46de844