### PR TITLE
feat: add film year hint with time penalty

### DIFF
--- a/src/app/api/tmdb/movies/route.ts
+++ b/src/app/api/tmdb/movies/route.ts
@@ -40,13 +40,19 @@ export async function GET(_req: NextRequest) {
         const backdrops = imgData.backdrops || [];
         const pick =
           backdrops[Math.floor(Math.random() * backdrops.length)] || null;
-        return {
-          id: m.id,
-          title: m.title,
-          backdrop_path: pick?.file_path || m.backdrop_path || null,
-        };
+          return {
+            id: m.id,
+            title: m.title,
+            release_date: m.release_date,
+            backdrop_path: pick?.file_path || m.backdrop_path || null,
+          };
       } catch {
-        return { id: m.id, title: m.title, backdrop_path: m.backdrop_path };
+          return {
+            id: m.id,
+            title: m.title,
+            release_date: m.release_date,
+            backdrop_path: m.backdrop_path,
+          };
       }
     })
   );


### PR DESCRIPTION
## Summary
- allow players to reveal the film's release year at the cost of 5 seconds
- include release date in TMDB movie API

## Testing
- `pnpm lint` *(fails: Command "lint" not found)*
- `pnpm typecheck` *(fails: Command "typecheck" not found)*
- `pnpm test:unit` *(fails: Command "test:unit" not found)*
- `pnpm e2e` *(fails: Command "e2e" not found)*
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689a0b1899a8832286eb51eebd061d5c