### PR TITLE
Start timer after image loads

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -102,7 +102,6 @@ export default function Game() {
     const url = `/api/img?path=${path}&w=1280`;
     setImgUrl(url);
     setQuestion((q) => q + 1);
-    setTimeout(() => setLoading(false), 150);
   }
 
   async function handleMistake() {
@@ -305,6 +304,8 @@ export default function Game() {
                 animate={{ opacity: 1, scale: 1 }}
                 exit={{ opacity: 0, scale: 0.98 }}
                 transition={{ duration: 0.35 }}
+                onLoad={() => setLoading(false)}
+                onError={() => setLoading(false)}
               />
             ) : (
               <motion.div


### PR DESCRIPTION
## Summary
- start round timer only after movie image is loaded

## Testing
- `pnpm lint` *(fails: Command "lint" not found)*
- `pnpm test:unit` *(fails: Command "test:unit" not found)*
- `pnpm typecheck` *(fails: Command "typecheck" not found)*
- `npx tsc -p tsconfig.json --noEmit`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68bad308bcdc832289e15034ef4d08da